### PR TITLE
Fix GEE dataset api call on new mapping

### DIFF
--- a/src/data/GeeDataSetD2ApiRepository.ts
+++ b/src/data/GeeDataSetD2ApiRepository.ts
@@ -4,6 +4,7 @@ import moment from "moment";
 import { Maybe } from "../domain/common/Maybe";
 import { GeeDataSet } from "../domain/entities/GeeDataSet";
 import { GeeDataSetRepository, GeeDataSetsFilter } from "../domain/repositories/GeeDataSetRepository";
+import _ from "lodash";
 
 export class GeeDataSetD2ApiRepository implements GeeDataSetRepository {
     private cachedGeeDataSets: GeeDataSetsCache | undefined;
@@ -35,16 +36,25 @@ export class GeeDataSetD2ApiRepository implements GeeDataSetRepository {
     }
 
     async getGeeApi(): Promise<GeeApiDataSet[]> {
-        const geeDataSetCatalog = "https://earthengine-stac.storage.googleapis.com/catalog/catalog.json";
+        const geeDataSetCatalog = "https://storage.googleapis.com/earthengine-stac/catalog/catalog.json";
         const { data: catalog } = await axios.get<GeeApiCatalog>(geeDataSetCatalog);
         const links = catalog.links.filter(link => link.rel === "child").map(link => link.href);
 
-        return Promise.all(
+        // Fetch parent links to fetch data for child links and flatten the result
+        const dataSetPromises = await Promise.all(
             links.map(async link => {
                 const { data } = await axios.get<GeeApiDataSet>(link);
-                return data;
+                const childLinks = data.links?.filter(link => link.rel === "child").map(link => link.href) || [];
+
+                return Promise.all(
+                    childLinks.map(async childLink => {
+                        const { data: childData } = await axios.get<GeeApiDataSet>(childLink);
+                        return childData;
+                    })
+                );
             })
         );
+        return _.flatten(dataSetPromises);
     }
 
     private async getDataSets(): Promise<GeeDataSet[]> {

--- a/src/webapp/components/gee-data-sets/GeeDataSetSelector.tsx
+++ b/src/webapp/components/gee-data-sets/GeeDataSetSelector.tsx
@@ -199,7 +199,6 @@ const GeeDataSetSelector: React.FC<GeeDataSetSelectorProps> = ({ onChange, float
                     className={classes.geeInput}
                     inputProps={{
                         readOnly: Boolean(true),
-                        disabled: Boolean(true),
                     }}
                     onClick={() => setOpen(true)}
                     label={floatingLabelText}


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** https://app.clickup.com/t/8694g99tv 
- 8694g99tv
-   **Issue:** Closes https://github.com/EyeSeeTea/dhis2-gee-app/issues/40

### :memo: Implementation

- GEE catalog api now send children links that we need to fetch to get `bands`, `interval` and `type`
- `TextArea` disable state was preventing `onClick` event to open the dialog

### :art: Screenshots
https://github.com/EyeSeeTea/dhis2-gee-app/assets/6376073/b9162a60-698e-43ff-9acb-c6b53b35811c

### :fire: How to test it? Go to `On-demand import > New mapping` and click on `G.E.E Dataset` input, then dialog should open

### :bookmark_tabs: Others
