### PR TITLE
[Fix] `yarn build` missing yarn command on build-folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "craco-start": "craco start",
         "prebuild": "yarn localize && yarn test",
         "build-folder": "rm -rf build/ && d2-manifest package.json manifest.webapp && react-scripts build && yarn run manifest && cp -r i18n icon.png build",
-        "build": "yarn localize && build-folder && rm -f $npm_package_name.zip && cd build && zip --quiet -r ../$npm_package_name.zip *",
+        "build": "yarn localize && yarn build-folder && rm -f $npm_package_name.zip && cd build && zip --quiet -r ../$npm_package_name.zip *",
         "build-importer": "REACT_APP_DATA_IMPORTER=true yarn build && yarn manifest-importer && rm -f $npm_package_name-importer.zip && cd build && zip -r ../$npm_package_name-importer.zip *",
         "test": "jest --passWithNoTests",
         "lint": "eslint src cypress --ext .js,.jsx,.ts,.tsx",


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** https://app.clickup.com/t/8694g99tv
- 8694g99tv

### :memo: Implementation

- On `yarn build`, `build-folder` wasn't prefix by `yarn`

### :fire: How to test it? (If there is any special consideration or the reviewer does not know how to test it)
- Launch `yarn build` and it should build properly 
