### PR TITLE
use default app namespace

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-09-22T09:56:12.389Z\n"
-"PO-Revision-Date: 2021-09-22T09:56:12.389Z\n"
+"POT-Creation-Date: 2024-06-25T18:52:49.837Z\n"
+"PO-Revision-Date: 2024-06-25T18:52:49.837Z\n"
 
 msgid "No effective import into DHIS2, file download"
 msgstr ""
@@ -284,6 +284,9 @@ msgid "Google Band mapping with Data Element.q"
 msgstr ""
 
 msgid "Click to show feedback"
+msgstr ""
+
+msgid "Imports"
 msgstr ""
 
 msgid "On-demand Import"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2021-09-22T09:56:12.389Z\n"
+"POT-Creation-Date: 2024-06-25T18:52:49.837Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -285,6 +285,9 @@ msgstr ""
 
 msgid "Click to show feedback"
 msgstr "Pinche para ver feedback"
+
+msgid "Imports"
+msgstr "Importaciones"
 
 msgid "On-demand Import"
 msgstr ""

--- a/i18n/pt.po
+++ b/i18n/pt.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2021-09-22T09:56:12.389Z\n"
+"POT-Creation-Date: 2024-06-25T18:52:49.837Z\n"
 "PO-Revision-Date: 2020-06-16T05:53:00.829Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -296,6 +296,10 @@ msgstr "Mapeamento do Google Band com Data Element.q"
 
 msgid "Click to show feedback"
 msgstr "Clique para mostrar comentários"
+
+#, fuzzy
+msgid "Imports"
+msgstr "Importar"
 
 msgid "On-demand Import"
 msgstr "Importação sob demanda"

--- a/i18n/pt.po
+++ b/i18n/pt.po
@@ -297,9 +297,8 @@ msgstr "Mapeamento do Google Band com Data Element.q"
 msgid "Click to show feedback"
 msgstr "Clique para mostrar comentários"
 
-#, fuzzy
 msgid "Imports"
-msgstr "Importar"
+msgstr ""
 
 msgid "On-demand Import"
 msgstr "Importação sob demanda"

--- a/src/types/i18n.d.ts
+++ b/src/types/i18n.d.ts
@@ -1,4 +1,5 @@
 declare module "@dhis2/d2-i18n" {
     export function t(value: string, namespace?: object): string;
     export function changeLanguage(locale: string);
+    export function setDefaultNamespace(namespace: string);
 }

--- a/src/webapp/contexts/app-context.ts
+++ b/src/webapp/contexts/app-context.ts
@@ -3,6 +3,7 @@ import CompositionRoot from "../../CompositionRoot";
 import { D2Api } from "../../types/d2-api";
 import { Config } from "../models/Config";
 import { User } from "../models/User";
+import i18n from "../../locales";
 
 export interface AppContextState {
     api: D2Api;
@@ -17,6 +18,7 @@ export const AppContext = React.createContext<AppContextState | null>(null);
 
 export function useAppContext() {
     const context = useContext(AppContext);
+    i18n.setDefaultNamespace("dhis2-gee-app");
     if (context) {
         return context;
     } else {

--- a/src/webapp/pages/home/HomePage.tsx
+++ b/src/webapp/pages/home/HomePage.tsx
@@ -14,7 +14,7 @@ const LandingPage: React.FC = () => {
         children: MenuCardProps[];
     }[] = [
         {
-            title: "Imports",
+            title: i18n.t("Imports"),
             key: "Main",
             children: [
                 {


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8694ubx3x

### :memo: Implementation
- [x] Update i18n types
- [x] Set default namespace in `app-context.ts`

### :art: Screenshots
<img width="828" alt="Screenshot 2024-06-25 at 19 58 25" src="https://github.com/EyeSeeTea/dhis2-gee-app/assets/37223065/08746589-1dbc-4a6c-8967-54aebacf3ae0">

### :fire: How to test it? (If there is any special consideration or the reviewer does not know how to test it)
I added a translation for `Imports` to test

### :bookmark_tabs: Others

#8694ubx3x