### PR TITLE
Fix double header bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ This project can generate two app zips.
 To generate the admin app:
 
 ```
-$ yarn build-webapp
+$ yarn build
 ```
 
 To generate the importer app:

--- a/src/webapp/components/header-bar/HeaderBar.tsx
+++ b/src/webapp/components/header-bar/HeaderBar.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { HeaderBar as D2HeaderBar } from "@dhis2/ui";
+
+type HeaderBarProps = {
+    appName: string;
+};
+
+// avoid rendering header for versions > 2.41
+// https://developers.dhis2.org/docs/references/global-shell/#header-bars
+export const HeaderBar: React.FC<HeaderBarProps> = ({ appName }) => {
+    const shouldRenderHeaderBar = window.self === window.top;
+    return shouldRenderHeaderBar ? <D2HeaderBar appName={appName} /> : null;
+};

--- a/src/webapp/pages/app/App.tsx
+++ b/src/webapp/pages/app/App.tsx
@@ -1,5 +1,4 @@
 import { useConfig } from "@dhis2/app-runtime";
-import { HeaderBar } from "@dhis2/ui";
 import { LoadingProvider, SnackbarProvider } from "@eyeseetea/d2-ui-components";
 import { MuiThemeProvider } from "@material-ui/core/styles";
 import { Feedback, FeedbackOptions } from "@eyeseetea/feedback-component";
@@ -9,6 +8,7 @@ import OldMuiThemeProvider from "material-ui/styles/MuiThemeProvider";
 import React, { useEffect, useState } from "react";
 import CompositionRoot from "../../../CompositionRoot";
 import { D2Api } from "../../../types/d2-api";
+import { HeaderBar } from "../../components/header-bar/HeaderBar";
 import Share from "../../components/share/Share";
 import { AppContext, AppContextState } from "../../contexts/app-context";
 import { Config } from "../../models/Config";


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #869dvn096 [Fix double header bar](https://app.clickup.com/t/4528615/869dvn096)

### :memo: Implementation

- DHIS2's global shell (>2.41) renders its own header bar when the app is embedded in an iframe, duplicating the HeaderBar this app already renders. Only render it when the app is loaded at the top level.
- fix yarn build in README

### :art: Screenshots

<img width="962" height="487" alt="Screenshot from 2026-07-20 14-25-36" src="https://github.com/user-attachments/assets/22aa06b7-4cad-4a48-9dd8-2414b4b9e672" />

### :fire: How to test it? (If there is any special consideration or the reviewer does not know how to test it)

### :bookmark_tabs: Others
Build the app install and check
Check also running it in local env